### PR TITLE
Fix warning on @check_filled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
+- Fix warning on @check_filled
 - Description messages for pass and fail do not leave artifacts if there are no details
 - Make messages consistent with "Subject predicate noun"
 

--- a/lib/dry/validation/matchers/validate_matcher.rb
+++ b/lib/dry/validation/matchers/validate_matcher.rb
@@ -50,6 +50,7 @@ module Dry::Validation::Matchers
       @acceptance = acceptance
       @type = DEFAULT_TYPE
       @value_rules = []
+      @check_filled = false
     end
 
     def description


### PR DESCRIPTION
I just fix a warning when `.filled(:type)` is not called on `validate(...)`

PS: Ok this time I think I got it. I think i'll remake the two other pull request to follow this.