### PR TITLE
Fix runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
+- Fix gemspec dependencies context
 - Description messages for pass and fail do not leave artifacts if there are no details
 - Make messages consistent with "Subject predicate noun"
 

--- a/dry-validation-matchers.gemspec
+++ b/dry-validation-matchers.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "activesupport"
-  spec.add_development_dependency "dry-validation"
+  spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency "dry-validation"
+  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
Fix a runtime dependencies.
dry-validation is needed for this gem to work at runtime, not only for development.