### PR TITLE
Fix false negative on type matchers checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
+- Fix date_time type error message
+- Fix false positive checks missmatch between type check and other checks
 - Description messages for pass and fail do not leave artifacts if there are no details
 - Make messages consistent with "Subject predicate noun"
 

--- a/lib/dry/validation/matchers/validate_matcher.rb
+++ b/lib/dry/validation/matchers/validate_matcher.rb
@@ -148,9 +148,12 @@ module Dry::Validation::Matchers
       result = schema.(@attr => TYPE_ERRORS[@type][:test_value])
       error_messages = result.errors[@attr]
       return true if error_messages.nil?
-      allowed_errors = [TYPE_ERRORS[@type][:message]] & error_messages
-      unallowed_errors = error_messages - allowed_errors
-      unallowed_errors.empty?
+      # Message not allowed are all the type_error_messages that are not the
+      # expected type. Any other message is accepted (like "size cannot be less than 20")
+      unallowed_errors = type_error_messages - [TYPE_ERRORS[@type][:message]]
+      # We check if error_messages intersect with the unallowed_errors.
+      # if intersection is empty, then the check is passed.
+      (error_messages & unallowed_errors).empty?
     end
 
     def check_value!(schema)
@@ -180,5 +183,12 @@ module Dry::Validation::Matchers
       false
     end
 
+    def type_error_messages
+      type_error_messages = []
+      TYPE_ERRORS.each_pair do |type, hash|
+        type_error_messages << hash[:message]
+      end
+      type_error_messages
+    end
   end
 end

--- a/lib/dry/validation/matchers/validate_matcher.rb
+++ b/lib/dry/validation/matchers/validate_matcher.rb
@@ -33,7 +33,7 @@ module Dry::Validation::Matchers
       },
       date_time: {
         test_value: DateTime.new(2011, 5, 1, 2, 3, 4),
-        message: "must be a date_time",
+        message: "must be a date time",
       },
       array: {
         test_value: [1, 3, 5],

--- a/spec/lib/dry/validation/matchers/validate_matcher_spec.rb
+++ b/spec/lib/dry/validation/matchers/validate_matcher_spec.rb
@@ -6,7 +6,7 @@ module Dry::Validation::Matchers
     let(:schema_class) do
       Class.new(Dry::Validation::Schema) do
         define! do
-          required(:username).filled
+          required(:username).filled(:str?, min_size?: 20)
           required(:first_name)
           required(:age).filled(:int?)
           required(:last_name).filled(:str?)


### PR DESCRIPTION
When there is more than one conditions on the .filled() call, then the validator failed on normally successful test.

The change in spec/lib/dry/validation/matchers/validate_matcher_spec.rb make the bug to show up.