### PR TITLE
Pull request/fix false positive value included_in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
+- Fix false positive on value(included_in:) matcher
 - Fix gemspec dependencies context
 - Fix warning on @check_filled
 - Description messages for pass and fail do not leave artifacts if there are no details

--- a/lib/dry/validation/matchers/validate_matcher.rb
+++ b/lib/dry/validation/matchers/validate_matcher.rb
@@ -170,7 +170,7 @@ module Dry::Validation::Matchers
         result = schema.(@attr => v)
         error_messages = result.errors[@attr]
         error_messages.present? && error_messages.grep(/must be one of/).any?
-      end.all? {|result| result == true}
+      end.any? {|result| result == true}
       return false if invalid_for_expected_values
 
       value_outside_required = allowed_values.sample.to_s + SecureRandom.hex(2)

--- a/spec/lib/dry/validation/matchers/validate_matcher_spec.rb
+++ b/spec/lib/dry/validation/matchers/validate_matcher_spec.rb
@@ -198,6 +198,10 @@ module Dry::Validation::Matchers
         matcher = described_class.new(:hair_color, :optional).
           value(included_in: %w(orange blue))
         expect(matcher.matches?(schema_class)).to be true
+
+        matcher = described_class.new(:hair_color, :optional).
+          value(included_in: %w(orange blue white))
+        expect(matcher.matches?(schema_class)).to be false
       end
     end
 


### PR DESCRIPTION
I noticed a problem while extending a included_in? list by beginning by my test.

It was passing the test even if the schema hasn't been changed.
It seems then that the line lib/dry/validation/matchers/validate_matcher.rb:173 was false because to fail it expect that none of the check value is accepted instead of one to be rejected to fail. Sorry if i'm not clear.

I think the corrected Spec is clear.