### PR TITLE
Set compatible dry-validation version to < 1.0

### DIFF
--- a/dry-validation-matchers.gemspec
+++ b/dry-validation-matchers.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "dry-validation"
+  spec.add_runtime_dependency "dry-validation", "< 1.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
1.0+ isn't support, yet (https://github.com/bloom-solutions/dry-validation-matchers/issues/17)