### PR TITLE
Replace BigDecimal.new with BigDecimal()

### DIFF
--- a/lib/dry/validation/matchers/validate_matcher.rb
+++ b/lib/dry/validation/matchers/validate_matcher.rb
@@ -16,7 +16,7 @@ module Dry::Validation::Matchers
         message: "must be a float",
       },
       decimal: {
-        test_value: BigDecimal.new("41.5"),
+        test_value: BigDecimal("41.5"),
         message: "must be a decimal",
       },
       bool: {


### PR DESCRIPTION
Deprecated in mri 2.5.0